### PR TITLE
CI 적용

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -1,0 +1,52 @@
+name: development build and push docker image to ghcr.io
+
+on:
+  push:
+    branches:
+      - develop
+    tags:
+      - "dev*"
+  pull_request:
+    branches:
+      - develop
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/chat_server
+
+jobs:
+  build-and-push:
+    name: build
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_ACCESS_TOKEN }}
+
+      - name: Extract metadata (tag, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern=dev{{version}}
+            type=semver,pattern=dev{{major}}.{{minor}}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./docker/Dockerfile.dev
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
develop 브랜치에 tag가 생성되거나 feature 브랜치가 푸시되면 container image 생성 후 ghcr.io에 push 하도록 github actions 설정

*#2 pr은 HEAD가 feature 브랜치라서 develop을 base로 하는 새로운 브랜치로 작업함 

issue:
- #7 