### PR TITLE
isort 옵션 제거

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,6 @@ repos:
     hooks:
     -   id: isort
         args:
-            - "-a"
-            - "from __future__ import annotations"
             - "--profile"
             - "black"
             - "-l 90"


### PR DESCRIPTION
__future__ annotation 버그로 인해 내부 모듈 import를 못하는 버그 발생

pre-commit isort에서 __future__ annotation 강제로 추가하는 옵션 제거