### PR TITLE
feat: Add authenticate by session id

### DIFF
--- a/app/common/authenticate.py
+++ b/app/common/authenticate.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from dataclasses import dataclass, field
+from typing import Dict, Generator, Iterator
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends, HTTPException, status
+from starlette.requests import Request
+from user.models import User
+from user.service import UserService, UserSessionService
+
+from .container import ApplicationContainer
+
+
+@dataclass(frozen=True)
+class Session:
+    storage: Dict[str, User] = field(default_factory=dict)
+
+    def __getitem__(self, key: str) -> User:
+        return self.storage.get(key, {})
+
+    def __setitem__(self, key: str, value: User) -> None:
+        self.storage.update({key: value})
+
+    def __iter__(self) -> Iterator:
+        return iter(self.storage.keys())
+
+    def get(self, key: str) -> User:
+        return self.storage.get(key, {})
+
+    def set(self, key: str, value: User) -> None:
+        self.storage.update({key: value})
+
+    def delete(self, key: str) -> None:
+        context = self.storage.pop(key)
+        del context
+
+    @classmethod
+    @inject
+    def verify(
+        cls,
+        request: Request,
+        user_service: UserService = Depends(Provide[ApplicationContainer.service.user]),
+        user_session_service: UserSessionService = Depends(
+            Provide[ApplicationContainer.service.user_session]
+        ),
+    ) -> Generator:
+        session_id: str = request.headers.get("x-session-id")
+        if not session_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Required Session id"
+            )
+        user_session = user_session_service.get_by_session_id(session_id=session_id)
+        if not user_session:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+            )
+        user = user_service.get_by_id(id=user_session.user_id)
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Not logged in"
+            )
+        cls.storage.update(key=session_id, value=user)
+        yield user
+
+    @classmethod
+    def get_local_session(self) -> Generator:
+        yield Session()

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title="Chat API Server", version=cfg.version)
     app.container = container
-    app.container.wire(modules=["user.router", "chat.router"])
+    app.container.wire(modules=["user.router", "chat.router", "common.authenticate"])
     app.include_router(user_router)
     app.include_router(chat_router)
 

--- a/app/user/errors.py
+++ b/app/user/errors.py
@@ -9,6 +9,11 @@ class UserNotFoundByIdError(NotFoundError):
         super().__init__(f"User(id={id!r}) not found")
 
 
+class UserNotFoundByEmailError(NotFoundError):
+    def __init__(self, email: str) -> None:
+        super().__init__(f"User({email=!r}) not found")
+
+
 class CannotCreateUserError(DatabaseIntegrityError):
     def __init__(self, name: str, email: str) -> None:
         super().__init__(f"Cannot create User({name=!r}, {email=!r})")

--- a/app/user/repository.py
+++ b/app/user/repository.py
@@ -10,8 +10,8 @@ from user.errors import (
     CannotCreateUserError,
     InvalidUserSessionError,
     NotExistUserError,
+    UserNotFoundByEmailError,
     UserNotFoundByIdError,
-    UserNotLoggedInError,
 )
 from user.models import User, UserSession
 
@@ -31,6 +31,13 @@ class UserRepository:
             user = session.query(User).filter(User.id == id).first()
             if not user:
                 raise UserNotFoundByIdError(id)
+            return user
+
+    def get_by_email(self, email: str) -> User:
+        with self.session_factory() as session:
+            user = session.query(User).filter(User.email == email).first()
+            if not user:
+                raise UserNotFoundByEmailError(email)
             return user
 
     def create(self, name: str, email: str, password: str) -> User:

--- a/app/user/request.py
+++ b/app/user/request.py
@@ -14,3 +14,8 @@ class UpdateUser(BaseModel):
     id: str
     password: str
     name: str
+
+
+class LoginUser(BaseModel):
+    email: str
+    password: str

--- a/app/user/router.py
+++ b/app/user/router.py
@@ -139,8 +139,10 @@ def delete_session_by_session_id(
         Provide[ApplicationContainer.service.user_session]
     ),
     current_uesr: User = Depends(Session.verify),
+    session_storage: Session = Depends(Session.get_local_session),
 ) -> Union[Response, JSONResponse]:
     try:
+        session_storage.delete(session_id)
         user_session.delete_by_session_id(session_id=session_id)
     except Exception as exception:
         error = ErrorResponse(

--- a/app/user/service.py
+++ b/app/user/service.py
@@ -22,6 +22,9 @@ class UserService:
     def get_by_id(self, id: int) -> User:
         return self._repository.get(id=id)
 
+    def get_by_email(self, email: str) -> User:
+        return self._repository.get_by_email(email)
+
     def create(self, name: str, email: str, password: str) -> User:
         return self._repository.create(name=name, email=email, password=password)
 


### PR DESCRIPTION
- 로컬 세션 storage 구현
- 세션 생성 시(로그인 시) storage에 현재 유저 정보 저장
- 유저 생성, 세션 생성 시를 제외한 api에서 세션 id 검사 로직 구현
- 세션 삭제 요청 시 세션 저장소에서 유저 정보 제거